### PR TITLE
Subset output data matrix for heatmap generation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,40 @@
+# This is a basic workflow to test Compter is working
+
+name: Compter Check
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master, devel, actions ]
+  pull_request:
+    branches: [ master, devel, actions ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+    # Runs a single command using the runners shell
+    - name: Run a one-line script
+      run: echo Hello, world!
+    
+    # Runs a set of commands using the runners shell
+    - name: Install dependencies
+      run: |
+        sudo apt-get update 
+        sudo apt install r-base-core
+        sudo su - -c "R -e \"install.packages('pheatmap', repos='http://cran.rstudio.com/')\""
+
+    # Run Compter
+    - name: Run Compter
+      run: |
+        $GITHUB_WORKSPACE/compter --background mouse --outfile testing.txt $GITHUB_WORKSPACE/test/high_seqs.fa $GITHUB_WORKSPACE/test/low_seqs.fa
+       

--- a/compter
+++ b/compter
@@ -282,7 +282,7 @@ pheatmap(compter.data,
          annotation=group.annotation,
          show_colnames=FALSE,
          main=file,
-				 cluster_cols=$nogroup,
+		 cluster_cols=$nogroup,
          breaks=seq(from=min.value,to=max.value,length.out=50),
          color=colorRampPalette(c("magenta","white","green"))(50),
          border.color = NA)
@@ -846,8 +846,10 @@ OPTIONS
                    loads of sequences into this analysis as the graphs will not
                    scale to very large sequence numbers.  Default 1000.
 
--n --nograph       Skip the drawing of the heatmap and just calculate the table
+--nograph          Skip the drawing of the heatmap and just calculate the table
                    of results.
+
+--nogroup          Do not cluster heatmap columns.
 
 -o --outfile       [Required] The name of the file to write the text 
                    based output to. If graphical output is produced then


### PR DESCRIPTION
The Compter output data files may be very large and too complex for generating heatmaps.  For this reason, the datafile is now susbet at regular intervals to create subset datasets of a manageable size which is used to create a heatmap.  These subset datasets are automatically deleted after the generation of the heatmap.